### PR TITLE
Fix grey spot in bottom right corner - mailchimp page - mobile devices

### DIFF
--- a/src/05-mailchimp/style.css
+++ b/src/05-mailchimp/style.css
@@ -3,7 +3,6 @@ html {
   word-spacing: 1px;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
-  background-color: #f7f7f7;
   color: #241c15;
   line-height: 1.5;
   font-family: 'Open Sans', sans-serif;
@@ -42,7 +41,8 @@ a:hover {
 .content-right {
   height: 100%;
   flex-grow: 1;
-	background-image: url("./undraw_my_password_d6kg.svg");
+  background-image: url("./undraw_my_password_d6kg.svg");
+  background-color: #f7f7f7;
 	background-position-y: 350px;
 	background-position-x: center;
   background-size: 600px;


### PR DESCRIPTION
Developer: `@your_username`
Description: Bugfix for Mailchimp login page with grey spot in bottom right corner [Issue #24](https://github.com/mazipan/login-page-css/issues/24)

Should be enough to move grey background from `html` element to `.content-right`